### PR TITLE
Compile nxp using -fPIC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test.py
 .eggs/
 nxp/
 .idea/
+*.so

--- a/get_nxpRdLib.sh
+++ b/get_nxpRdLib.sh
@@ -25,8 +25,9 @@ nxp() {
     rm nxp.zip
   fi
 
+  rm -rf nxp/build/*
   pushd nxp/build > /dev/null
-  cmake ..
+  CFLAGS=-fPIC cmake ..
   make NxpRdLibLinuxPN512
   popd > /dev/null
 }


### PR DESCRIPTION
This PR should close #48 

In some cases, the python extension could not link against the nxp library because it wasn't set to produce position independent code.

Also, the build directory was not cleaned up, so multiple runs of build did not guarantee a rebuild of the library.