### PR TITLE
Replaced custom build command with build_ext

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mifare = nxppy.Mifare()
 # Select the first available tag and return the UID
 uid = mifare.select()
 
-# Read a single block of 4 bytes from block 10 
+# Read a single block of 4 bytes from block 10
 block10bytes = mifare.read_block(10)
 
 # Write a single block of 4 bytes
@@ -62,7 +62,7 @@ while True:
     except nxppy.SelectError:
         # SelectError is raised if no card is in the field.
         pass
-        
+
     time.sleep(1)
 ```
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 from distutils.core import Extension
-from distutils.command.build import build
+from distutils.command.build_ext import build_ext
 import sys
 from subprocess import call
 
@@ -29,7 +29,7 @@ nxppy = Extension('nxppy',
 
 
 # noinspection PyShadowingBuiltins
-class BuildNxppy(build):
+class BuildNxppy(build_ext):
     def run(self):
         # noinspection PyUnusedLocal
         def compile(extra_preargs=None):
@@ -45,7 +45,7 @@ class BuildNxppy(build):
         self.execute(compile, [], 'compiling NxpRdLib')
 
         # Run the rest of the build
-        build.run(self)
+        build_ext.run(self)
 
 
 short_description = 'A python extension for interfacing with the NXP PN512 NFC Reader. Targeted specifically for ' \
@@ -68,4 +68,4 @@ setup(name='nxppy',
       author_email='svvitale@gmail.com',
       url='http://github.com/svvitale/nxppy',
       ext_modules=[nxppy],
-      cmdclass={'build': BuildNxppy})
+      cmdclass={'build_ext': BuildNxppy})


### PR DESCRIPTION
`build` is only run in specific scenarios, e.g.

    pip install nxppy
    python setup.py build

It is not run when doing

    pip install -e nxppy/
    python setup.py develop

`build_ext` is run in any case as the extension is compiled in all cases.