### PR TITLE
Replaced dependency installation with description in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,18 @@ The EXPLORE-NFC card relies on SPI being enabled. Please enable SPI using raspi-
 
 Installation
 =====
-nxppy is available from PyPI.  To install, simply run:
+
+nxppy is available from PyPI.  To install, first install the dependencies, e.g. on Raspian (replace `python3-dev` with `python2-dev` if you are using Python 2)
 
 ```
-sudo pip install nxppy
+sudo apt-get update
+sudo apt-get install build-essential cmake python3-dev unzip wget
+```
+
+then simply run.
+
+```
+pip install nxppy
 ```
 
 Installation will take some time as it automatically pulls down the NXP NFC Reader Library from souce.

--- a/get_nxpRdLib.sh
+++ b/get_nxpRdLib.sh
@@ -3,18 +3,6 @@
 blue='\033[0;34m'
 NC='\033[0m' # No Color
 
-prereq() {
-  PREREQS="build-essential cmake $1"
-  
-  if dpkg -s $PREREQS > /dev/null 2>&1; then
-    echo -e "Prerequisites already installed: $PREREQS"
-  else
-    echo -e "[${blue}Installing prerequisites${NC}]"
-    sudo apt-get update
-    sudo apt-get -y install $PREREQS
-  fi
-}
-
 nxp() {
   if [[ -d "nxp" ]]; then
     echo -e "NXP Reader Library found, skipping download"
@@ -36,7 +24,6 @@ cleanup() {
 }
 
 all() {
-  prereq $@
   nxp
   cleanup
 }
@@ -46,4 +33,3 @@ if [[ $# -eq 0 ]]; then
 else
   $@
 fi
-

--- a/setup.py
+++ b/setup.py
@@ -33,14 +33,7 @@ class BuildNxppy(build):
     def run(self):
         # noinspection PyUnusedLocal
         def compile(extra_preargs=None):
-            if sys.version_info >= (3, 0):
-                python_lib = 'python3-dev'
-            elif sys.version_info >= (2, 7):
-                python_lib = 'python2.7-dev'
-            else:
-                raise ValueError("Python version not supported")
-
-            call('./get_nxpRdLib.sh all ' + python_lib, shell=True)
+            call('./get_nxpRdLib.sh all', shell=True)
 
         self.execute(compile, [], 'compiling NxpRdLib')
 


### PR DESCRIPTION
This should close #47

Not everyone is using Raspbian and running pip install as sudo is highly discouraged.

The easiest solution for both issues is, like all other packages are doing, to not install the dependencies in this package, but have the user install them beforehand.